### PR TITLE
feat: add port name for prometheus-jmx-exporter

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -49,7 +49,8 @@ spec:
           - {{ .Values.prometheus.jmx.port | quote }}
           - /etc/jmx-kafka-connect/jmx-kafka-connect-prometheus.yml
           ports:
-          - containerPort: {{ .Values.prometheus.jmx.port }}
+          - name: jmx-exporter
+            containerPort: {{ .Values.prometheus.jmx.port }}
           resources:
 {{ toYaml .Values.prometheus.jmx.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
## What changes were proposed in this pull request?
podmonitor를 쓰려면 port name이 필요함.

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
